### PR TITLE
[TabView] Remove unwanted behaviour inherited by ListView

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/TabView/TabViewItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TabView/TabViewItem.cs
@@ -4,6 +4,8 @@
 
 using System;
 using Windows.Devices.Input;
+using Windows.System;
+using Windows.UI.Core;
 using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -58,8 +60,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <inheritdoc/>
         protected override void OnPointerPressed(PointerRoutedEventArgs e)
         {
-            base.OnPointerPressed(e);
-
             _isMiddleClick = false;
 
             if (e.Pointer.PointerDeviceType == PointerDeviceType.Mouse)
@@ -71,7 +71,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _isMiddleClick = true;
                 }
+                
+                // Disable unwanted behaviour inherited by ListView:
+                // Disable "Ctrl + Left Click" to deselect tab
+                if (pointerPoint.Properties.IsLeftButtonPressed)
+                {
+                    var ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control);
+                    if (ctrl.HasFlag(CoreVirtualKeyStates.Down))
+                    {
+                        e.Handled = true;
+                    }
+                }
             }
+            
+            base.OnPointerPressed(e);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
In TabView, you can deselect a tab by "Ctrl + Left Click" which is a behavior inherited by ListView (I guess). This should not be considered as a default behavior for TabView and should be disabled by default.

Issue: #
https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/2931

## PR Type
What kind of change does this PR introduce?
<!-- - Feature -->

## What is the current behavior?
Ctrl + Left Clicking a TabViewItem causes all items to deselect and their content to disappear.

## What is the new behavior?
Ctrl + Left click should not deselect selected tab by default. This is not wanted behavior for TabView.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x ] Contains **NO** breaking changes

## Other information
